### PR TITLE
Fix EGL Window resize, Qt window hierarchy changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DISTRIBUTOR "None" CACHE STRING "Name of the distributor.")
 if(UNIX AND NOT APPLE AND NOT ANDROID)
   option(ENABLE_X11 "Enables X11 Support" ON)
   option(ENABLE_WAYLAND "Enables Wayland Support" OFF)
+  include(CMakeDependentOption)
   cmake_dependent_option(ENABLE_WAYLAND_NOGUI "Enables Wayland Support in dolphin-emu-nogui" ON
                          ENABLE_WAYLAND OFF)
 endif()

--- a/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGLWayland.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/GL/GLInterface/EGLWayland.h"
-#include <cstdio>
+#include "VideoCommon/RenderBase.h"
 
 GLContextEGLWayland::~GLContextEGLWayland()
 {
@@ -14,18 +14,32 @@ GLContextEGLWayland::~GLContextEGLWayland()
 
 void GLContextEGLWayland::Update()
 {
-  m_backbuffer_width = -1;
-  m_backbuffer_height = -1;
+  int width = g_renderer->GetNewWidth();
+  int height = g_renderer->GetNewHeight();
+
+  wl_egl_window_resize(m_egl_window, width, height, 0, 0);
+
+  m_backbuffer_width = width;
+  m_backbuffer_height = height;
 }
 
 EGLDisplay GLContextEGLWayland::OpenEGLDisplay()
 {
-  return eglGetDisplay(static_cast<NativeDisplayType>(m_wsi.display_connection));
+  return eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR,
+                               static_cast<wl_display*>(m_wsi.display_connection), nullptr);
 }
 
 EGLNativeWindowType GLContextEGLWayland::GetEGLNativeWindow(EGLConfig config)
 {
+  if (m_egl_window)
+    wl_egl_window_destroy(m_egl_window);
+
+  // If passed handle is null, use the interlock to mutually synchronize host and renderer.
+  if (m_wsi.render_surface == nullptr)
+    m_wsi.render_surface = g_renderer->WaitForNewSurface();
+
   m_egl_window = wl_egl_window_create(static_cast<struct wl_surface*>(m_wsi.render_surface),
                                       m_wsi.width, m_wsi.height);
+
   return static_cast<NativeWindowType>(m_egl_window);
 }

--- a/Source/Core/DolphinNoGUI/PlatformWayland.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformWayland.cpp
@@ -128,8 +128,6 @@ private:
   struct xkb_keymap* m_xkb_map = nullptr;
   struct xkb_state* m_xkb_state = nullptr;
 
-  int32_t m_window_x = Config::Get(Config::MAIN_RENDER_WINDOW_XPOS);
-  int32_t m_window_y = Config::Get(Config::MAIN_RENDER_WINDOW_YPOS);
   int32_t m_window_width = Config::Get(Config::MAIN_RENDER_WINDOW_WIDTH);
   int32_t m_window_height = Config::Get(Config::MAIN_RENDER_WINDOW_HEIGHT);
   int32_t m_scaling_factor = 1;
@@ -333,8 +331,8 @@ void PlatformWayland::xdg_toplevel_handle_configure(void* data, struct xdg_tople
   }
   else
   {
-    xdg_surface_set_window_geometry(platform->m_xdg_surface, platform->m_window_x,
-                                    platform->m_window_y, platform->m_window_width,
+    xdg_surface_set_window_geometry(platform->m_xdg_surface, 0,
+                                    0, platform->m_window_width,
                                     platform->m_window_height);
     wl_surface_commit(platform->m_surface);
   }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -52,6 +52,23 @@ void Host::SetRenderHandle(void* handle)
   }
 }
 
+void Host::BlockForSurfaceDestroy()
+{
+  if (g_renderer)
+    g_renderer->BlockHostForSurfaceDestroy();
+}
+
+void Host::UnblockWithNewSurface(void* surface)
+{
+  m_render_handle = surface;
+  if (g_renderer)
+  {
+    g_renderer->UnblockRendererWithNewSurface(surface);
+    if (g_controller_interface.IsInit())
+      g_controller_interface.ChangeWindow(surface);
+  }
+}
+
 bool Host::GetRenderFocus()
 {
   return m_render_focus;

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -24,6 +24,8 @@ public:
   bool GetRenderFullscreen();
 
   void SetRenderHandle(void* handle);
+  void BlockForSurfaceDestroy();
+  void UnblockWithNewSurface(void* surface);
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
   void ResizeSurface(int new_width, int new_height);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -32,7 +32,6 @@
 
 #include "Common/ScopeGuard.h"
 #include "Common/Version.h"
-#include "Common/WindowSystemInfo.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
@@ -196,7 +195,7 @@ static std::vector<std::string> StringListToStdVector(QStringList list)
 
 MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
                        const std::string& movie_path)
-    : QMainWindow(nullptr)
+    : QMainWindow(nullptr), m_wsi_type(GetWindowSystemType())
 {
   setWindowTitle(QString::fromStdString(Common::scm_rev_str));
   setWindowIcon(Resources::GetAppIcon());
@@ -372,7 +371,7 @@ void MainWindow::CreateComponents()
   m_tool_bar = new ToolBar(this);
   m_search_bar = new SearchBar(this);
   m_game_list = new GameList(this);
-  m_render_widget = new RenderWidget;
+  m_render_widget = new RenderWidget(m_wsi_type);
   m_stack = new QStackedWidget(this);
 
   for (int i = 0; i < 4; i++)
@@ -1058,7 +1057,7 @@ void MainWindow::HideRenderWidget(bool reinit)
     m_render_widget->removeEventFilter(this);
     m_render_widget->deleteLater();
 
-    m_render_widget = new RenderWidget;
+    m_render_widget = new RenderWidget(m_wsi_type);
 
     m_render_widget->installEventFilter(this);
     connect(m_render_widget, &RenderWidget::Closed, this, &MainWindow::ForceStop);
@@ -1136,7 +1135,7 @@ void MainWindow::ShowGraphicsWindow()
   if (!m_graphics_window)
   {
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-    if (GetWindowSystemType() == WindowSystemType::X11)
+    if (m_wsi_type == WindowSystemType::X11)
     {
       m_xrr_config = std::make_unique<X11Utils::XRRConfiguration>(
           static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
@@ -1416,7 +1415,7 @@ void MainWindow::NetPlayQuit()
 void MainWindow::EnableScreenSaver(bool enable)
 {
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  if (GetWindowSystemType() == WindowSystemType::X11)
+  if (m_wsi_type == WindowSystemType::X11)
     UICommon::EnableScreenSaver(winId(), enable);
 #else
   UICommon::EnableScreenSaver(enable);

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -11,6 +11,8 @@
 #include <optional>
 #include <string>
 
+#include "Common/WindowSystemInfo.h"
+
 class QProgressDialog;
 class QStackedWidget;
 class QString;
@@ -193,6 +195,7 @@ private:
   std::unique_ptr<X11Utils::XRRConfiguration> m_xrr_config;
 #endif
 
+  WindowSystemType m_wsi_type;
   QProgressDialog* m_progress_dialog = nullptr;
   QStackedWidget* m_stack;
   ToolBar* m_tool_bar;

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -7,6 +7,8 @@
 #include <QEvent>
 #include <QWidget>
 
+#include "Common/WindowSystemInfo.h"
+
 class QMouseEvent;
 class QTimer;
 
@@ -15,7 +17,7 @@ class RenderWidget final : public QWidget
   Q_OBJECT
 
 public:
-  explicit RenderWidget(QWidget* parent = nullptr);
+  explicit RenderWidget(WindowSystemType wsi_type, QWidget* parent = nullptr);
 
   bool event(QEvent* event) override;
   void showFullScreen();
@@ -25,6 +27,8 @@ signals:
   void EscapePressed();
   void Closed();
   void HandleChanged(void* handle);
+  void SurfaceAboutToBeDestroyed();
+  void SurfaceCreated(void* handle);
   void StateChanged(bool fullscreen);
   void SizeChanged(int new_width, int new_height);
   void FocusChanged(bool focus);
@@ -42,4 +46,5 @@ private:
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;
   QPoint m_last_mouse{};
+  WindowSystemType m_wsi_type;
 };

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -129,6 +129,12 @@ elseif(ANDROID)
   )
 endif()
 
+if(ENABLE_WAYLAND AND WAYLAND_FOUND)
+  target_link_libraries(inputcommon PUBLIC
+    ${XKBCOMMON_LIBRARIES}
+  )
+endif()
+
 if(ANDROID)
   target_sources(inputcommon PRIVATE GCAdapter_Android.cpp)
 else()

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1112,18 +1112,8 @@ void Renderer::CheckForSurfaceResize()
     return;
 
   m_main_gl_context->Update();
-  if (m_backbuffer_width == -1 && m_backbuffer_height == -1 && m_new_width != -1 &&
-      m_new_height != -1)
-  {
-    // We're on a system where we need to get the size from the toolkit
-    m_backbuffer_width = m_new_width;
-    m_backbuffer_height = m_new_height;
-  }
-  else
-  {
-    m_backbuffer_width = m_main_gl_context->GetBackBufferWidth();
-    m_backbuffer_height = m_main_gl_context->GetBackBufferHeight();
-  }
+  m_backbuffer_width = m_main_gl_context->GetBackBufferWidth();
+  m_backbuffer_height = m_main_gl_context->GetBackBufferHeight();
   m_system_framebuffer->UpdateDimensions(m_backbuffer_width, m_backbuffer_height);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -570,6 +570,11 @@ bool SwapChain::RecreateSurface(void* native_handle)
   DestroySwapChain();
   DestroySurface();
 
+  // If passed handle is null (Wayland), use the interlock to mutually synchronize host and
+  // renderer.
+  if (native_handle == nullptr)
+    native_handle = g_renderer->WaitForNewSurface();
+
   // Re-create the surface with the new native handle
   m_wsi.render_surface = native_handle;
   m_surface = CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_wsi);

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(videocommon
   ShaderGenCommon.h
   Statistics.cpp
   Statistics.h
+  SurfaceChangeInterlock.cpp
+  SurfaceChangeInterlock.h
   TextureCacheBase.cpp
   TextureCacheBase.h
   TextureConfig.cpp

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -625,6 +625,23 @@ void Renderer::ChangeSurface(void* new_surface_handle)
   m_surface_changed.Set();
 }
 
+void Renderer::BlockHostForSurfaceDestroy()
+{
+  m_new_surface_handle = nullptr;
+  m_surface_changed.Set();
+  m_surface_change_interlock.BlockHostForSurfaceDestroy();
+}
+
+void Renderer::UnblockRendererWithNewSurface(void* surface)
+{
+  m_surface_change_interlock.UnblockRendererWithNewSurface(surface);
+}
+
+void* Renderer::WaitForNewSurface()
+{
+  return m_surface_change_interlock.WaitForNewSurface();
+}
+
 void Renderer::ResizeSurface(int width, int height)
 {
   std::lock_guard<std::mutex> lock(m_swap_mutex);

--- a/Source/Core/VideoCommon/SurfaceChangeInterlock.cpp
+++ b/Source/Core/VideoCommon/SurfaceChangeInterlock.cpp
@@ -1,0 +1,34 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/SurfaceChangeInterlock.h"
+
+#include "Common/Assert.h"
+
+void SurfaceChangeInterlock::BlockHostForSurfaceDestroy()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::NotBlocking);
+  m_state = State::BlockingHost;
+  m_host_cv.wait(lock);
+}
+
+void SurfaceChangeInterlock::UnblockRendererWithNewSurface(void* native_handle)
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::BlockingRenderer);
+  m_native_handle = native_handle;
+  m_renderer_cv.notify_one();
+}
+
+void* SurfaceChangeInterlock::WaitForNewSurface()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::BlockingHost);
+  m_host_cv.notify_one();
+  m_state = State::BlockingRenderer;
+  m_renderer_cv.wait(lock);
+  m_state = State::NotBlocking;
+  return m_native_handle;
+}

--- a/Source/Core/VideoCommon/SurfaceChangeInterlock.h
+++ b/Source/Core/VideoCommon/SurfaceChangeInterlock.h
@@ -1,0 +1,37 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+// ---------------------------------------------------------------------------------------------
+// Stateful interlock for synchronizing surface changes between host and renderer threads.
+// It first blocks the host thread until the rendering surface can be safely destroyed.
+// Then it blocks the rendering thread until the host comes back with a new surface.
+//
+// Designed to work with Wayland platform, but can be used for any platform that depends
+// on synchronous surface changes.
+// ---------------------------------------------------------------------------------------------
+
+#include <condition_variable>
+#include <mutex>
+
+class SurfaceChangeInterlock
+{
+  enum class State
+  {
+    NotBlocking,
+    BlockingHost,
+    BlockingRenderer
+  };
+
+public:
+  void BlockHostForSurfaceDestroy();
+  void UnblockRendererWithNewSurface(void* native_handle);
+  void* WaitForNewSurface();
+
+private:
+  std::mutex m_mutex;
+  std::condition_variable m_host_cv;
+  std::condition_variable m_renderer_cv;
+  void* m_native_handle = nullptr;
+  State m_state = State::NotBlocking;
+};

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -87,6 +87,7 @@
     <ClCompile Include="UberShaderCommon.cpp" />
     <ClCompile Include="UberShaderPixel.cpp" />
     <ClCompile Include="Statistics.cpp" />
+    <ClCompile Include="SurfaceChangeInterlock.cpp" />
     <ClCompile Include="GeometryShaderGen.cpp" />
     <ClCompile Include="GeometryShaderManager.cpp" />
     <ClCompile Include="TextureCacheBase.cpp" />
@@ -165,6 +166,7 @@
     <ClInclude Include="SamplerCommon.h" />
     <ClInclude Include="ShaderGenCommon.h" />
     <ClInclude Include="Statistics.h" />
+    <ClInclude Include="SurfaceChangeInterlock.h" />
     <ClInclude Include="GeometryShaderGen.h" />
     <ClInclude Include="GeometryShaderManager.h" />
     <ClInclude Include="TextureCacheBase.h" />


### PR DESCRIPTION
Hi!

Glad to see somebody else working on Wayland support for Dolphin.

I've also been working on Wayland support in my own branch, but I like your platform base better (particularly CMake stuff and you actually have preliminary NoGUI support).

I've made some changes to fix resizing EGL windows. There's also synchronous handling of wl_surface destruction and recreation (whenever the Qt widget hierarchy changes).

I have a few other pieces to add to your base, namely a wl_seat input backend and a parent rendering widget to enable drawing client-side decorations.